### PR TITLE
Update test file with new name

### DIFF
--- a/configure_project.sh
+++ b/configure_project.sh
@@ -23,6 +23,7 @@ echo -e "\n${BLUE}Renaming variables and files...${NC}\n"
 sed -i s/$DUMMY_MODULE/$MODULE/g dev.Dockerfile
 sed -i s/$DUMMY_MODULE/$MODULE/g prod.Dockerfile
 sed -i s/$DUMMY_MODULE/$MODULE/g tests/context.py
+sed -i s/$DUMMY_MODULE/$MODULE/g tests/test_app.py
 mv $DUMMY_MODULE $MODULE
 
 sed -i s/$DUMMY_MODULE/$MODULE/g pytest.ini


### PR DESCRIPTION
The test file doesn't update with a new project name and thus they fail because they can't import from the original package name.